### PR TITLE
ci: adb uninstall "com.hoc081098.kmp.viewmodel.compose.test"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -279,4 +279,5 @@ jobs:
           script: |
             adb logcat -c
             adb logcat *:E &
+            adb uninstall "com.hoc081098.kmp.viewmodel.compose.test"
             ./gradlew :viewmodel-compose:connectedDebugAndroidTest


### PR DESCRIPTION
https://github.com/ReactiveCircus/android-emulator-runner/issues/319